### PR TITLE
Fix permissions on the run.bash script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,5 +37,6 @@ RUN cd gz-test; mkdir build;
 WORKDIR /home/$USERNAME/gz-test/build
 RUN cmake ../ -DBUILD_TESTING=false; sudo make install
 
-COPY --chown=$USERNAME:$USERNAME run.bash ./
+WORKDIR /home/$USERNAME
+COPY --chmod=0755 --chown=$USERNAME:$USERNAME run.bash ./
 ENTRYPOINT ["./run.bash"]

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -51,5 +51,5 @@ shift
 
 rm -rf gz-test
 git clone git@github.com:gazebosim/gz-test -b main
-docker build --rm -t $image_name --build-arg user_id=$user_id .
+DOCKER_BUILDKIT=1 docker build --rm -t $image_name --build-arg user_id=$user_id .
 rm -rf gz-test


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

The `run.bash` script had incorrect permissions when building the docker image.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.